### PR TITLE
Both mnemonics and passphrase must be NFKD

### DIFF
--- a/js/trezor-recovery.js
+++ b/js/trezor-recovery.js
@@ -141,7 +141,7 @@
     function onCalculateBIP39Clicked() {
         var mnemonic = $("#bip32_source_mnemonic").val();
         var passphrase = $("#bip32_source_passphrase").val();
-        bip32_passphrase_hash = CryptoJS.PBKDF2(mnemonic, "mnemonic" + passphrase, { keySize: 512/32, iterations: 2048, hasher: CryptoJS.algo.SHA512 }).toString();
+        bip32_passphrase_hash = CryptoJS.PBKDF2(mnemonic.normalize('NFKD'), "mnemonic" + passphrase.normalize('NFKD'), { keySize: 512/32, iterations: 2048, hasher: CryptoJS.algo.SHA512 }).toString();
         updatePassphraseHash();
     }
 


### PR DESCRIPTION
as per BIP39 specs, all strings must be NFKD normalized.

ASCII characters do not change, so English wordlist is not affected... however, non-English phrases will fail to recover under this currently.


Also, browser support for String.prototype.normalize is not complete... so browserifying the npm 'unorm' and using it might be a better option.